### PR TITLE
Fix invocation of build_depends.sh in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
-`basename $0`/build_depends.sh
+`dirname $0`/build_depends.sh
 make
 
 echo '


### PR DESCRIPTION
I guess you wanted to use `dirname` here.