### PR TITLE
libdevcheck: Fix portability issues with GNU C

### DIFF
--- a/libdevcheck/copy.c
+++ b/libdevcheck/copy.c
@@ -1,3 +1,5 @@
+#define _GNU_SOURCE
+
 #define _FILE_OFFSET_BITS 64
 #include <stdlib.h>
 #include <string.h>

--- a/libdevcheck/posix_write_zeros.c
+++ b/libdevcheck/posix_write_zeros.c
@@ -1,3 +1,5 @@
+#define _GNU_SOURCE
+
 #define _FILE_OFFSET_BITS 64
 #include <stdio.h>
 #include <stdlib.h>

--- a/libdevcheck/read_test.c
+++ b/libdevcheck/read_test.c
@@ -1,3 +1,5 @@
+#define _GNU_SOURCE
+
 #define _FILE_OFFSET_BITS 64
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
The libdevcheck component is explicitly dependent on GNU C extensions,
such as asprintf. Additionally with glibc, O_NOATIME is only exposed
when _GNU_SOURCE is defined.

As such, #define _GNU_SOURCE is the dependent components of libdevcheck
to ensure that this builds with compliance on GLibc using platforms.

Signed-off-by: Ikey Doherty <ikey@solus-project.com>