### PR TITLE
Update static libraries 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.4)
+cmake_minimum_required(VERSION 2.8.1)
 include(ExternalProject)
 project(whdd)
 

--- a/external/dialog/CMakeLists.txt
+++ b/external/dialog/CMakeLists.txt
@@ -1,11 +1,11 @@
-cmake_minimum_required(VERSION 2.8.4)
+cmake_minimum_required(VERSION 2.8.1)
 include(ExternalProject)
 project(dialog)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../ncurses ${CMAKE_CURRENT_SOURCE_DIR}/../ncurses)
 set(CURSES_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../ncurses/install")
 ExternalProject_Add(dialog
     DEPENDS ncurses
-    URL ftp://invisible-island.net/dialog/dialog-1.2-20140219.tgz
+    URL ftp://ftp.invisible-island.net/dialog/dialog-1.3-20171209.tgz
     BUILD_IN_SOURCE 1
     CONFIGURE_COMMAND bash -c "LD_LIBRARY_PATH=${CURSES_DIR}/lib LDFLAGS=\"-ltinfo -L${CURSES_DIR}/lib\" ./configure --with-curses-dir=${CURSES_DIR} --with-ncursesw --enable-widec --disable-rc-file"
     INSTALL_COMMAND echo Fake install

--- a/external/ncurses/CMakeLists.txt
+++ b/external/ncurses/CMakeLists.txt
@@ -1,9 +1,9 @@
-cmake_minimum_required(VERSION 2.8.4)
+cmake_minimum_required(VERSION 2.8.1)
 include(ExternalProject)
 project(ncurses)
 set(INSTALL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/install")
 ExternalProject_Add(ncurses
-    URL http://ftp.gnu.org/pub/gnu/ncurses/ncurses-5.9.tar.gz
+    URL http://ftp.gnu.org/pub/gnu/ncurses/ncurses-6.1.tar.gz
     BUILD_IN_SOURCE 1
     CONFIGURE_COMMAND ./configure --enable-widec --without-gpm --prefix=${INSTALL_DIR} --with-terminfo-dirs=/usr/share/terminfo:/lib/terminfo --with-termlib --with-shared
     BUILD_COMMAND make


### PR DESCRIPTION
1)Downgrade minimal cmake requirements to be able to compile with system cmake under ubuntu 10.04
2)Change URL of dialog static library to correct one
3)Update dialog and ncurses static libraries to make visibility of dialog windows lines correct under ubuntu 10.04 