### PR TITLE
Add NVMe SSD support ("/dev/nvme0nN")

### DIFF
--- a/libdevcheck/libdevcheck.c
+++ b/libdevcheck/libdevcheck.c
@@ -105,6 +105,11 @@ static int is_whole_disk(const char *name) {
     if (!strncmp(name, "mmcblk", 6)) {
         return !strchr(name + 6, 'p');
     }
+    // NVMe SSD have "nvme0nN" for whole devices,
+    // and "nvme0nNpM" for partitions
+    if (!strncmp(name, "nvme", 4)) {
+        return !strchr(name + 6, 'p');
+    }
     // taken from util-linux-2.19.1/lib/wholedisk.c
     while (*name)
         name++;


### PR DESCRIPTION
whdd doesn't support latest NVMe SSD drives - /dev/nvme0nN , here is patch for /dev/nvme0nN support.
NVMe SSD drives supports SMART, so, please check if command "Show SMART attributes" will be visible for these drives.

Thanks for nice tool,
Mantas Kriaučiūnas,
http://launchpad.net/baltix
http://tinklas.eu