### PR TITLE
Fix build static

### DIFF
--- a/cui/sliding_window_renderer.c
+++ b/cui/sliding_window_renderer.c
@@ -131,9 +131,9 @@ static void render_update_stats(SlidingWindow *priv) {
     werase(priv->access_time_stats);
     unsigned int i;
     for (i = 0; i < 6; i++)
-        wprintw(priv->access_time_stats, "%d\n", priv->access_time_stats_accum[i]);
+        wprintw(priv->access_time_stats, "%ld\n", priv->access_time_stats_accum[i]);
     for (i = 1; i < 7; i++)
-        wprintw(priv->access_time_stats, "%d\n", priv->error_stats_accum[i]);
+        wprintw(priv->access_time_stats, "%ld\n", priv->error_stats_accum[i]);
     wnoutrefresh(priv->access_time_stats);
 
     if (priv->avg_processing_speed != 0) {
@@ -247,7 +247,7 @@ static int Open(DC_RendererCtx *ctx) {
     wnoutrefresh(priv->w_end_lba);
     wprintw(priv->summary,
             "%s %s\n"
-            "Block = %d bytes\n"
+            "Block = %ld bytes\n"
             "Ctrl+C to abort\n",
             actctx->procedure->display_name, actctx->dev->dev_path, actctx->blk_size);
     wrefresh(priv->summary);

--- a/external/dialog/CMakeLists.txt
+++ b/external/dialog/CMakeLists.txt
@@ -5,7 +5,7 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../ncurses ${CMAKE_CURRENT_SOURCE_D
 set(CURSES_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../ncurses/install")
 ExternalProject_Add(dialog
     DEPENDS ncurses
-    URL ftp://invisible-island.net/dialog/dialog-1.2-20140219.tgz
+    URL https://invisible-island.net/archives/dialog/dialog-1.3-20220414.tgz
     BUILD_IN_SOURCE 1
     CONFIGURE_COMMAND bash -c "LD_LIBRARY_PATH=${CURSES_DIR}/lib LDFLAGS=\"-ltinfo -L${CURSES_DIR}/lib\" ./configure --with-curses-dir=${CURSES_DIR} --with-ncursesw --enable-widec --disable-rc-file"
     INSTALL_COMMAND echo Fake install

--- a/external/ncurses/CMakeLists.txt
+++ b/external/ncurses/CMakeLists.txt
@@ -3,7 +3,7 @@ include(ExternalProject)
 project(ncurses)
 set(INSTALL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/install")
 ExternalProject_Add(ncurses
-    URL http://ftp.gnu.org/pub/gnu/ncurses/ncurses-5.9.tar.gz
+    URL https://ftp.gnu.org/pub/gnu/ncurses/ncurses-6.3.tar.gz
     BUILD_IN_SOURCE 1
     CONFIGURE_COMMAND ./configure --enable-widec --without-gpm --prefix=${INSTALL_DIR} --with-terminfo-dirs=/usr/share/terminfo:/lib/terminfo --with-termlib --with-shared
     BUILD_COMMAND make

--- a/libdevcheck/copy.c
+++ b/libdevcheck/copy.c
@@ -1,4 +1,5 @@
 #define _FILE_OFFSET_BITS 64
+#define _GNU_SOURCE
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>

--- a/libdevcheck/posix_write_zeros.c
+++ b/libdevcheck/posix_write_zeros.c
@@ -1,4 +1,5 @@
 #define _FILE_OFFSET_BITS 64
+#define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/libdevcheck/read_test.c
+++ b/libdevcheck/read_test.c
@@ -1,4 +1,5 @@
 #define _FILE_OFFSET_BITS 64
+#define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
- Updated version Dialog and Ncurses libs
- Changed libs sources to SSL (HTTPS)
- Fix errors with undeclared functions
- Some warnings fix

Build tested with:
```shell
$ cmake --version
cmake version 2.8.12.2
...
$ gcc --version
gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-44)
...
```
and

```shell
$ cmake --version   
cmake version 3.20.5
...
$ gcc --version
gcc (GCC) 11.2.1 20220127 (Red Hat 11.2.1-9)
...
```