### PR TITLE
fix full static build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,9 @@ add_dependencies(whdd version)
 target_link_libraries(whdd rt pthread)
 
 if (${STATIC})
-
+    # full static build
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -static -no-pie")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static -no-pie")
     # Set vars containing to deps builds
     set(NCURSES_DIR "${CMAKE_CURRENT_SOURCE_DIR}/external/ncurses/install/")
     set(DIALOG_DIR "${CMAKE_CURRENT_SOURCE_DIR}/external/dialog/dialog-prefix/src/dialog/")


### PR DESCRIPTION
* "CMakeList.txt" old version not build full static program,run on other system need *.so.1 , this static compilation can be ported to other systems without dependencies .